### PR TITLE
Updated RPM spec and added useful modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,29 @@
-.PHONY: build install dist rpm_sources srpm rpm pypi clean
+.PHONY: build install dist srpm rpm pypi clean
 
-PROJECT := psys
-PYTHON := python
-RPM_SOURCES_PATH := ~/rpmbuild/SOURCES
+PYTHON        ?= python
+INSTALL_FLAGS ?=
+
+NAME          := psys
+RPM_NAME      := python-$(NAME)
 
 build:
 	$(PYTHON) setup.py build
 
 install:
-	$(PYTHON) setup.py install --skip-build
+	$(PYTHON) setup.py install --skip-build $(INSTALL_FLAGS)
 
 dist: clean
 	$(PYTHON) setup.py sdist
+	mv dist/$(NAME)-*.tar.gz .
 
-rpm_sources: dist
-	cp dist/* $(RPM_SOURCES_PATH)/
+srpm: dist
+	rpmbuild -bs --define "_sourcedir $(CURDIR)" $(RPM_NAME).spec
 
-srpm: rpm_sources
-	rpmbuild -bs python-$(PROJECT).spec
-
-rpm: rpm_sources
-	rpmbuild -ba python-$(PROJECT).spec
+rpm: dist
+	rpmbuild -ba --define "_sourcedir $(CURDIR)" $(RPM_NAME).spec
 
 pypi: clean
 	$(PYTHON) setup.py sdist upload
 
 clean:
-	rm -rf build dist $(PROJECT).egg-info
+	rm -rf build dist $(NAME)-*.tar.gz $(NAME).egg-info

--- a/psys/__init__.py
+++ b/psys/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from pcore import bytes, str, range
+from pcore import constants
 
 import collections
 import errno
@@ -119,7 +120,7 @@ def join_thread(thread, timeout=None):
         # Python is buggy: if we simply join a thread in the main thread
         # without a timeout, we will never receive any UNIX signal.
         while thread.isAlive():
-            thread.join(float(24 * 60 * 60))
+            thread.join(float(constants.DAY_SECONDS))
 
         return True
     else:

--- a/psys/daemon.py
+++ b/psys/daemon.py
@@ -115,9 +115,8 @@ def daemonize(do_fork=True, skip_fds=[]):
     signal.signal(signal.SIGHUP, signal.SIG_IGN)
     signal.siginterrupt(signal.SIGHUP, False)
 
-    # Redirecting stdout and stderr to the log file and
-    # closing the original stdin.
-    # -->
+    # Redirecting standard streams to /dev/null and
+    # closing original descriptors -->
     null_dev = eintr_retry(os.open)("/dev/null", os.O_RDWR)
     try:
         for fd in [sys.stdin.fileno(), sys.stdout.fileno(), sys.stderr.fileno()]:

--- a/psys/daemon.py
+++ b/psys/daemon.py
@@ -92,9 +92,9 @@ def write_pidfile(fd):
     datalen = len(data)
 
     while data:
-        size = os.write(fd, data)
+        size = eintr_retry(os.write)(fd, data)
         data = data[size:]
-    os.ftruncate(fd, datalen)
+    eintr_retry(os.ftruncate)(fd, datalen)
 
 
 def daemonize(do_fork=True, skip_fds=[]):

--- a/psys/daemon.py
+++ b/psys/daemon.py
@@ -82,3 +82,15 @@ def release_pidfile(path, fd):
         eintr_retry(os.unlink)(path)
     finally:
         eintr_retry(os.close)(fd)
+
+
+def write_pidfile(fd):
+    """Write pid to pidfile previously allocated by acquire_pidfile()"""
+
+    data = str(os.getpid())
+    datalen = len(data)
+
+    while data:
+        size = os.write(fd, data)
+        data = data[size:]
+    os.ftruncate(fd, datalen)

--- a/psys/pipe.py
+++ b/psys/pipe.py
@@ -1,0 +1,55 @@
+"""Provides a wrapper around a UNIX pipe."""
+
+import fcntl
+import logging
+import os
+
+from psys import eintr_retry
+
+
+LOG = logging.getLogger(__name__)
+"""Logger instance."""
+
+
+class Pipe(object):
+    """Represents a UNIX pipe."""
+
+    read = None
+    """Read FD."""
+
+    write = None
+    """Write FD."""
+
+    def __init__(self, nonblock=False):
+        self.read, self.write = os.pipe()
+
+        try:
+            if nonblock:
+                for fd in self.read, self.write:
+                    flags = eintr_retry(fcntl.fcntl)(fd, fcntl.F_GETFL)
+                    eintr_retry(fcntl.fcntl)(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+        except:
+            self.close()
+            raise
+
+    def __del__(self):
+        self.close()
+
+    def close(self, read=True, write=True):
+        """Closes the pipe."""
+
+        if read and self.read is not None:
+            try:
+                eintr_retry(os.close)(self.read)
+            except Exception as e:
+                LOG.error("Unable to close a pipe: %s.", e)
+            else:
+                self.read = None
+
+        if write and self.write is not None:
+            try:
+                eintr_retry(os.close)(self.write)
+            except Exception as e:
+                LOG.error("Unable to close a pipe: %s.", e)
+            else:
+                self.write = None

--- a/psys/process.py
+++ b/psys/process.py
@@ -1,0 +1,83 @@
+import logging
+import os
+import signal
+
+
+LOG = logging.getLogger(__name__)
+"""Logger instance."""
+
+_TERMINATE_SIGNAL_HANDLERS = []
+"""
+SIGINT, SIGQUIT and SIGTERM handlers that was added by
+add_terminate_signal_handler().
+"""
+
+_END_WORK_SIGNAL_RECEIVED = False
+"""True, if the program received end work UNIX signal."""
+
+
+def add_terminate_signal_handler(handler):
+    """Sets a handler for SIGINT, SIGQUIT and SIGTERM signals."""
+
+    _TERMINATE_SIGNAL_HANDLERS.append(handler)
+    return handler
+
+
+def remove_terminate_signal_handler(handler):
+    """Removes handler added by add_terminate_signal_handler()."""
+
+    _TERMINATE_SIGNAL_HANDLERS.remove(handler)
+
+
+def end_work_signal_received():
+    """Returns True if the program received end work UNIX signal."""
+
+    return _END_WORK_SIGNAL_RECEIVED
+
+
+def __signal_handler(signum, stack):
+    """Handler for the UNIX signals."""
+
+    LOG.info("Program received deadly UNIX signal [%s].", signum)
+
+    global _END_WORK_SIGNAL_RECEIVED
+    _END_WORK_SIGNAL_RECEIVED = True
+
+    if _TERMINATE_SIGNAL_HANDLERS:
+        for handler in _TERMINATE_SIGNAL_HANDLERS:
+            try:
+                LOG.info("Calling terminate UNIX signal handler %s...", handler)
+                handler()
+            except Exception as e:
+                LOG.error("Error while calling a terminate signal handler: %s.", e)
+
+
+def init(handle_unix_signals=True):
+    """
+    Starts the UNIX signals handling.
+    When the program gets a signal the corresponding signal handlers is invoked.
+    """
+
+    if handle_unix_signals:
+        signal.signal(signal.SIGINT, __signal_handler)
+        signal.siginterrupt(signal.SIGINT, False)
+
+        signal.signal(signal.SIGQUIT, __signal_handler)
+        signal.siginterrupt(signal.SIGQUIT, False)
+
+        signal.signal(signal.SIGTERM, __signal_handler)
+        signal.siginterrupt(signal.SIGTERM, False)
+
+        signal.siginterrupt(signal.SIGCHLD, False)
+        signal.siginterrupt(signal.SIGPIPE, False)
+
+    # Setting the proper PATH environment variable -->
+    required_paths = "/sbin:/usr/sbin:/bin:/usr/bin"
+    paths = os.getenv("PATH", required_paths).split(":")
+
+    for path in required_paths.split(":"):
+        if path not in paths:
+            paths.append(path)
+
+    os.environ.update(PATH=":".join(paths))
+    # Setting the proper PATH environment variable <--

--- a/python-psys.spec
+++ b/python-psys.spec
@@ -53,18 +53,18 @@ A Python module with a set of basic tools for writing system utilities
 
 
 %build
-%{__python2} setup.py build
+make PYTHON=%{__python2}
 %if 0%{with python3}
-%{__python3} setup.py build
+make PYTHON=%{__python3}
 %endif  # with python3
 
 
 %install
 [ "%buildroot" = "/" ] || rm -rf "%buildroot"
 
-%{__python2} setup.py install -O1 --skip-build --root "%buildroot"
+make PYTHON=%{__python2} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 %if 0%{with python3}
-%{__python3} setup.py install -O1 --skip-build --root "%buildroot"
+make PYTHON=%{__python3} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 %endif  # with python3
 
 

--- a/python-psys.spec
+++ b/python-psys.spec
@@ -1,17 +1,35 @@
-%{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%if 0%{?fedora} > 12 || 0%{?rhel} > 7
+%bcond_without python3
+%else
+%bcond_with python3
+%endif
 
-Name:    python-psys
+%if 0%{?rhel} && 0%{?rhel} <= 6
+%{!?__python2: %global __python2 /usr/bin/python2}
+%{!?python2_sitelib: %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%endif
+%if 0%{with python3}
+%{!?__python3: %global __python3 /usr/bin/python3}
+%{!?python3_sitelib: %global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%endif  # with python3
+
+%define project_name psys
+
+Name:    python-%project_name
 Version: 0.3
 Release: 1%{?dist}
 Summary: A Python module with a set of basic tools for writing system utilities
 
 Group:   Development/Languages
 License: GPLv3
-URL:     http://github.com/KonishchevDmitry/psys
-Source:  http://pypi.python.org/packages/source/p/psys/psys-%{version}.tar.gz
+URL:     http://github.com/KonishchevDmitry/%project_name
+Source:  http://pypi.python.org/packages/source/p/%project_name/%project_name-%{version}.tar.gz
 
 BuildArch:     noarch
-BuildRequires: python-setuptools
+BuildRequires: python2-devel python-setuptools
+%if 0%{with python3}
+BuildRequires: python3-devel python3-setuptools
+%endif  # with python3
 
 Requires: python-pcore
 
@@ -19,25 +37,50 @@ Requires: python-pcore
 A Python module with a set of basic tools for writing system utilities
 
 
+%if 0%{with python3}
+%package -n python3-%project_name
+Summary: A Python module with a set of basic tools for writing system utilities
+
+Requires: python3-pcore
+
+%description -n python3-%project_name
+A Python module with a set of basic tools for writing system utilities
+%endif  # with python3
+
+
 %prep
-%setup -n psys-%version -q
+%setup -n %project_name-%version -q
 
 
 %build
-%{__python} setup.py build
+%{__python2} setup.py build
+%if 0%{with python3}
+%{__python3} setup.py build
+%endif  # with python3
 
 
 %install
 [ "%buildroot" = "/" ] || rm -rf "%buildroot"
 
-%{__python} setup.py install -O1 --skip-build --root "%buildroot"
+%{__python2} setup.py install -O1 --skip-build --root "%buildroot"
+%if 0%{with python3}
+%{__python3} setup.py install -O1 --skip-build --root "%buildroot"
+%endif  # with python3
 
 
 %files
 %defattr(-,root,root,-)
+%{python2_sitelib}/psys
+%{python2_sitelib}/psys-*.egg-info
+%doc ChangeLog README INSTALL
 
-%python_sitelib/psys
-%python_sitelib/psys-*.egg-info
+%if 0%{with python3}
+%files -n python3-%project_name
+%defattr(-,root,root,-)
+%{python3_sitelib}/psys
+%{python3_sitelib}/psys-*.egg-info
+%doc ChangeLog README INSTALL
+%endif  # with python3
 
 
 %clean


### PR DESCRIPTION
- added rhel6/7 and `python3` support in RPM spec
- added `psys.process` module with process initialization and termination signal handling function
- added `psys.pipe` module with UNIX Pipe wrapper
- added `psys.daemon.write_pidfile` function
- refactored `Makefile`

RPMs for testing will be available in [copr repository](https://copr.fedorainfracloud.org/coprs/miushanov/pyaddons/build/180546/).
