### PR TITLE
Add python3 package build for EPEL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+Version 0.4
+-----------
+ * psys.pipe module
+ * psys.process module
+ * psys.daemon.write_pidfile() and psys.daemonize() functions
+
+
 Version 0.3
 -----------
  * pcore has been separated to an independent package

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ INSTALL_FLAGS ?=
 
 NAME          := psys
 RPM_NAME      := python-$(NAME)
-VERSION       := 0.3
+VERSION       := $(shell $(PYTHON) setup.py --version)
 
 build:
 	$(PYTHON) setup.py build

--- a/python-psys.spec
+++ b/python-psys.spec
@@ -16,7 +16,7 @@
 %define project_name psys
 
 Name:    python-%project_name
-Version: 0.3
+Version: 0.4
 Release: 1%{?dist}
 Summary: A Python module with a set of basic tools for writing system utilities
 

--- a/python-psys.spec
+++ b/python-psys.spec
@@ -16,7 +16,7 @@
 %define project_name psys
 
 Name:    python-%project_name
-Version: 0.3
+Version: 0.4
 Release: 1%{?dist}
 Summary: A Python module with a set of basic tools for writing system utilities
 
@@ -88,6 +88,11 @@ make PYTHON=%{__python3} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 
 
 %changelog
+* Thu Apr 28 2016 Dmitry Konishchev <konishchev@gmail.com> - 0.4-1
+- Add psys.pipe module
+- Add psys.process module
+- Add psys.daemon.write_pidfile() and psys.daemonize() functions
+
 * Mon Nov 18 2013 Dmitry Konishchev <konishchev@gmail.com> - 0.3-1
 - New version
 

--- a/python-psys.spec
+++ b/python-psys.spec
@@ -24,7 +24,7 @@ A Python module with a set of basic tools for writing system utilities}
 
 Name:    python-%project_name
 Version: 0.4
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A Python module with a set of basic tools for writing system utilities
 
 Group:   Development/Languages
@@ -116,6 +116,9 @@ make PYTHON=%{__python3_other} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 
 
 %changelog
+* Sun Jan 13 2019 Mikhail Ushanov <gm.mephisto@gmail.com> - 0.4-2
+- Add python3 package build for EPEL
+
 * Thu Apr 28 2016 Dmitry Konishchev <konishchev@gmail.com> - 0.4-1
 - Add psys.pipe module
 - Add psys.process module

--- a/python-psys.spec
+++ b/python-psys.spec
@@ -1,19 +1,26 @@
-%if 0%{?fedora} > 12 || 0%{?rhel} > 7
+%if 0%{?fedora} > 12 || 0%{?epel} >= 6
 %bcond_without python3
 %else
 %bcond_with python3
 %endif
 
-%if 0%{?rhel} && 0%{?rhel} <= 6
+%if 0%{?epel} >= 7
+%bcond_without python3_other
+%endif
+
+%if 0%{?rhel} <= 6
 %{!?__python2: %global __python2 /usr/bin/python2}
 %{!?python2_sitelib: %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %endif
 %if 0%{with python3}
 %{!?__python3: %global __python3 /usr/bin/python3}
 %{!?python3_sitelib: %global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%{!?python3_pkgversion: %global python3_pkgversion 3}
 %endif  # with python3
 
 %define project_name psys
+%global project_description %{expand:
+A Python module with a set of basic tools for writing system utilities}
 
 Name:    python-%project_name
 Version: 0.4
@@ -27,25 +34,32 @@ Source:  http://pypi.python.org/packages/source/p/%project_name/%project_name-%{
 
 BuildArch:     noarch
 BuildRequires: python2-devel python-setuptools
-%if 0%{with python3}
-BuildRequires: python3-devel python3-setuptools
-%endif  # with python3
 
 Requires: python-pcore
 
-%description
-A Python module with a set of basic tools for writing system utilities
+%description %{project_description}
 
 
 %if 0%{with python3}
-%package -n python3-%project_name
-Summary: A Python module with a set of basic tools for writing system utilities
+%package -n python%{python3_pkgversion}-%project_name
+Summary: %{summary}
+Requires: python%{python3_pkgversion}-pcore
+BuildRequires: python%{python3_pkgversion}-devel
+BuildRequires: python%{python3_pkgversion}-setuptools
 
-Requires: python3-pcore
-
-%description -n python3-%project_name
-A Python module with a set of basic tools for writing system utilities
+%description -n python%{python3_pkgversion}-%project_name %{project_description}
 %endif  # with python3
+
+
+%if 0%{with python3_other}
+%package -n python%{python3_other_pkgversion}-%project_name
+Summary: %{summary}
+Requires: python%{python3_other_pkgversion}-pcore
+BuildRequires: python%{python3_other_pkgversion}-devel
+BuildRequires: python%{python3_other_pkgversion}-setuptools
+
+%description -n python%{python3_other_pkgversion}-%project_name %{project_description}
+%endif  # with python3_other
 
 
 %prep
@@ -57,6 +71,9 @@ make PYTHON=%{__python2}
 %if 0%{with python3}
 make PYTHON=%{__python3}
 %endif  # with python3
+%if 0%{with python3_other}
+make PYTHON=%{__python3_other}
+%endif  # with python3_other
 
 
 %install
@@ -66,6 +83,9 @@ make PYTHON=%{__python2} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 %if 0%{with python3}
 make PYTHON=%{__python3} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 %endif  # with python3
+%if 0%{with python3_other}
+make PYTHON=%{__python3_other} INSTALL_FLAGS="-O1 --root '%buildroot'" install
+%endif  # with python3_other
 
 
 %files
@@ -75,12 +95,20 @@ make PYTHON=%{__python3} INSTALL_FLAGS="-O1 --root '%buildroot'" install
 %doc ChangeLog README INSTALL
 
 %if 0%{with python3}
-%files -n python3-%project_name
+%files -n python%{python3_pkgversion}-%project_name
 %defattr(-,root,root,-)
 %{python3_sitelib}/psys
 %{python3_sitelib}/psys-*.egg-info
 %doc ChangeLog README INSTALL
 %endif  # with python3
+
+%if 0%{with python3_other}
+%files -n python%{python3_other_pkgversion}-%project_name
+%defattr(-,root,root,-)
+%{python3_other_sitelib}/psys
+%{python3_other_sitelib}/psys-*.egg-info
+%doc ChangeLog README INSTALL
+%endif  # with python3_other
 
 
 %clean

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     with open("README") as readme:
         setup(
             name = "psys",
-            version = "0.3",
+            version = "0.4",
 
             description = readme.readline().strip(),
             long_description = readme.read().strip() or None,


### PR DESCRIPTION
* Сборка `python3` и `python3_other` для EPEL. Тестовый билд - https://copr.fedorainfracloud.org/coprs/miushanov/pyaddons-testing/build/846235/
* Промержен тег `0.4` в `master`. Коммит, на который он поставлен, был без бранча.